### PR TITLE
 Disregard blocks before contract deployment

### DIFF
--- a/scripts/abis/Registry.json
+++ b/scripts/abis/Registry.json
@@ -784,14 +784,7 @@
     "name": "solc",
     "version": "0.4.24+commit.e67f0147.Emscripten.clang"
   },
-  "networks": {
-    "ganache": {
-      "events": {},
-      "links": {},
-      "address": "0xe76cf43d2381c099d788b4eaaeea0e76e69a230f",
-      "transactionHash": "0x1078481ab928c393984654c7c38ac66682750b41c6295e1e34b6d52de74f49c1"
-    }
-  },
+  "networks": {},
   "schemaVersion": "2.0.1",
   "updatedAt": "2018-09-10T21:54:56.053Z"
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
 export const ipfsABIsHash = 'QmQieeNGuJt8sVVaVKFzT9iwRgFSztQfkoX9yrQwHfZibe'
 export const ipfsTokensHash = 'QmRH8e8ssnj1CWVepGvAdwaADKNkEpgDU5bffTbeS6JuG9'
 // hardcoded FORCED registry address
-export const hardcodedRegistryAddress = '0x0cc82efef656d836bb27548297bee4eb0cb6559e'
+export const hardcodedRegistryAddress = '0x0ba217252e67ab3832fbfc6af9b0ab4132d6eb84'
 export const defaultRegistryAddress = ''
 
 export function getIpfsABIsHash(tokenAddress) {

--- a/src/modules/home/sagas/index.js
+++ b/src/modules/home/sagas/index.js
@@ -14,7 +14,7 @@ export function* genesis() {
   try {
     const ethjs = yield call(getEthjs)
     const networkID = yield call(ethjs.net_version)
-    const network = 'ganache'
+    const network = 'rinkeby'
     const account = (yield call(ethjs.accounts))[0]
 
     if (account === undefined) {

--- a/src/modules/logs/sagas/index.js
+++ b/src/modules/logs/sagas/index.js
@@ -33,7 +33,7 @@ function* getFreshLogs() {
 
     // block range to search
     const blockRange = {
-      fromBlock: network === 'mainnet' ? 5000000 : 0,
+      fromBlock: network === 'rinkeby' ? 3812614 : 0,
       toBlock: 'latest',
     }
 

--- a/src/modules/logs/sagas/utils.js
+++ b/src/modules/logs/sagas/utils.js
@@ -5,7 +5,7 @@ import * as actions from '../actions'
 import * as types from '../types'
 
 export function* getSortedLogsSaga(
-  blockRange = { fromBlock: '0', toBlock: 'latest' },
+  blockRange = { fromBlock: '3812614', toBlock: 'latest' },
   eventNames = [],
   contract
 ) {


### PR DESCRIPTION
- This should cut initial load time by 20-30 seconds